### PR TITLE
deploy.sh: don't pass auth token on argv

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash ./shell.nix
 
-set -eux
+set -euxo pipefail
 
 PROJECT_NAME=bonk-api
 
 nix build .#packages.x86_64-linux.dockerImage
+# note: will write auth token to XDG_RUNTIME_DIR
+flyctl auth token | skopeo login -u x --password-stdin registry.fly.io
 skopeo \
     --insecure-policy \
     copy docker-archive:"$(realpath ./result)" \
     docker://registry.fly.io/$PROJECT_NAME:latest \
-    --dest-creds x:"$(flyctl auth token)" \
     --format v2s2
 
 flyctl deploy -i registry.fly.io/$PROJECT_NAME:latest --remote-only


### PR DESCRIPTION
This prevents it from being readable to all users on the system while skopeo is running.