### PR TITLE
Logout when we exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -55,13 +56,14 @@ func main() {
 		Ephemeral: true,
 		Hostname: "bonk",
 	}
+	defer s.Close()
 
 	tsclient, err := s.LocalClient()
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer tsclient.Logout(context.Background())
 
-	defer s.Close()
 	ln, err := s.Listen("tcp", *addr)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
This means we can re-login with the same hostname without changing anything else.

I'm not certain context.Background() is correct, but it needs a context. This should only be problematic if it takes a while to communicate to Tailscale that we logged out, but Fly.io kills the service before that completes.