### PR TITLE
Add goSum link to buildGoModule

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,12 +16,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
-        "revCount": 782401,
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "revCount": 788136,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.782401%2Brev-2631b0b7abcea6e640ce31cd78ea58910d31e650/01962c8a-63c4-7abd-a3df-63a17b548cc7/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.788136%2Brev-8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7/019666b0-bb20-78ff-bdc8-39c1e789baac/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
 
           src = ./.;
 
+          goSum = ./go.sum;
           vendorHash = "sha256-4bEkKL5ctmz+yE4YqncYKGKQfSejy/XQ/QDKrOB1A8M=";
         };
 


### PR DESCRIPTION
This should improve CI ergonomics as outlined here: https://docs.determinate.systems/guides/automatically-fix-hashes-in-github-actions